### PR TITLE
カスタムコンポーネントを作る時のエラー対策

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "module": "es2015",
         "moduleResolution": "node",
         "strict": true,
+        "strictPropertyInitialization": false,
         "sourceMap": true,
         "experimentalDecorators": true,
         "baseUrl": "./",


### PR DESCRIPTION
class Hoge { name!: string; } 等するときにコンパイラがエラーを吐く．
ビックリマークはTS 2.8以降の機能らしい．
Lintのバージョンが古いせいなのか，めっちゃエラーを出してくるけどコンパイルは通る．